### PR TITLE
chore: add `symfony/yaml` component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "symfony/http-kernel": "~4",
         "symfony/monolog-bridge": "~5",
         "symfony/property-access": "~4",
-        "symfony/property-info": "~4"
+        "symfony/property-info": "~4",
+        "symfony/yaml": "~4"
     },
     "suggest": {
         "symfony/console": "The Symfony Console component eases the creation of command line interfaces. Require this in your project if you wish to use the ePoetry Console.",


### PR DESCRIPTION
Hello,

While trying the PR #53 and trying to make it compatible with Symfony 5, I noticed that the `symfony/yaml` component is required for the tests.
That component is not declared in `require-dev`. It currently does not make issues because it is pulled in by `openeuropa/code-review` .

To highlight the issue locally, remove the lines `openeuropa/code-review` and `openeuropa/task-runner` then `composer i`, then run the tests:

![image](https://user-images.githubusercontent.com/252042/220304642-d7e17e62-da2c-4db9-b0e4-0244a2575d03.png)

This PR fix this by adding the missing `symfony/yaml` component.