### PR TITLE
feat: add CAS ticket validation using `ecphp/ecas`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "colinodell/psr-testlogger": "^1.1",
         "doctrine/annotations": "^1.13",
+        "ecphp/ecas": "^4",
         "monolog/monolog": "^2.8",
         "nyholm/psr7": "^1.4",
         "openeuropa/code-review": "^2.0",
@@ -35,6 +36,7 @@
         "phpdocumentor/reflection-docblock": "^5",
         "phpunit/phpunit": "~9.6",
         "react/http": "^1.8",
+        "symfony/cache": "^5.4",
         "symfony/dotenv": "~5.4 || ~6",
         "symfony/expression-language": "~5.4 || ~6",
         "symfony/http-kernel": "~5.4 || ~6",
@@ -43,6 +45,7 @@
         "symfony/property-info": "~5.4 || ~6"
     },
     "suggest": {
+        "ecphp/ecas": "Require this library in your project if you use the ECAS authentication",
         "symfony/console": "The Symfony Console component eases the creation of command line interfaces. Require this in your project if you wish to use the ePoetry Console.",
         "facile-it/php-openid-client": "Require this in your project if you use the OpenID Connect authentication plugin.",
         "web-token/jwt-signature-algorithm-hmac": "Require this in your project if you use the OpenID Connect authentication plugin. It requres php >=8.1.",

--- a/src/TicketValidation/ECas/ECasTicketValidation.php
+++ b/src/TicketValidation/ECas/ECasTicketValidation.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEuropa\EPoetry\TicketValidation\ECas;
+
+use EcPhp\CasLib\Contract\CasInterface;
+use EcPhp\CasLib\Contract\Response\Type\ServiceValidate as TypeServiceValidate;
+use OpenEuropa\EPoetry\Notification\Exception\NotificationValidationException;
+use OpenEuropa\EPoetry\TicketValidation\TicketValidationInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+use VeeWee\Xml\Dom\Traverser\Visitor\RemoveNamespaces;
+use function VeeWee\Xml\Dom\Configurator\traverse;
+use function VeeWee\Xml\Encoding\xml_decode;
+
+final class ECasTicketValidation implements TicketValidationInterface
+{
+    /**
+     * @param string $jobAccount
+     *    Job account of ePoetry service.
+     *    A ticket is considered valid if it is associated with a job account
+     *    that matches this one.
+     *    Check the following documentation for the actual value:
+     *    @link https://citnet.tech.ec.europa.eu/CITnet/confluence/pages/viewpage.action?pageId=973319436
+     */
+    public function __construct(
+        private readonly string $jobAccount,
+        private readonly CasInterface $cas
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validate(RequestInterface $notificationRequest): bool
+    {
+        try {
+            $ticket = $this->extractTicket($notificationRequest);
+        } catch (Throwable $exception) {
+            throw new NotificationValidationException(
+                sprintf(
+                    'EU Login ticket validation failed due to the following error: %s',
+                    $exception->getMessage()
+                ),
+                $exception->getCode(),
+                $exception
+            );
+        }
+
+        try {
+            /** @var TypeServiceValidate $response */
+            $response = $this
+                ->cas
+                ->requestTicketValidation(
+                    $notificationRequest,
+                    ['ticket' => $ticket]
+                );
+        } catch (Throwable $exception) {
+            throw new NotificationValidationException(
+                sprintf(
+                    'EU Login ticket validation failed with the following error: %s %s',
+                    $exception->getCode(),
+                    $exception->getMessage(),
+                ),
+                $exception->getCode(),
+                $exception
+            );
+        }
+
+        if ($this->jobAccount !== $user = $response->getCredentials()['user'] ?? '') {
+            throw new NotificationValidationException(
+                sprintf(
+                    'EU Login ticket account mismatched: %s was expected, while %s was returned.',
+                    $this->jobAccount,
+                    $user
+                )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Extract ticket from request.
+     *
+     * @throws NotificationValidationException
+     */
+    private function extractTicket(ServerRequestInterface $request): string
+    {
+        $data = xml_decode(
+            $request->getBody()->getContents(),
+            traverse(new RemoveNamespaces())
+        );
+
+        if (!isset($data['Envelope']['Header']['ProxyTicket'])) {
+            throw new NotificationValidationException('Request body element <ProxyTicket/> not found.');
+        }
+
+        $ticket = trim($data['Envelope']['Header']['ProxyTicket']);
+
+        if ('' === $ticket) {
+            throw new NotificationValidationException('Request body element <ProxyTicket/> found, but empty.');
+        }
+
+        return $ticket;
+    }
+}

--- a/tests/Notification/ReceiveNotificationWithECasTest.php
+++ b/tests/Notification/ReceiveNotificationWithECasTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace OpenEuropa\EPoetry\Tests\Notification;
+
+use EcPhp\CasLib\Cas;
+use EcPhp\CasLib\Configuration\Properties;
+use EcPhp\CasLib\Contract\CasInterface;
+use EcPhp\CasLib\Response\CasResponseBuilder;
+use EcPhp\CasLib\Response\Factory\AuthenticationFailureFactory;
+use EcPhp\CasLib\Response\Factory\ProxyFactory;
+use EcPhp\CasLib\Response\Factory\ProxyFailureFactory;
+use EcPhp\CasLib\Response\Factory\ServiceValidateFactory;
+use EcPhp\Ecas\Ecas;
+use EcPhp\Ecas\EcasProperties;
+use EcPhp\Ecas\Response\EcasResponseBuilder;
+use EcPhp\Ecas\Service\Fingerprint\DefaultFingerprint;
+use Exception;
+use GuzzleHttp\Psr7\ServerRequest;
+use loophp\psr17\Psr17;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use OpenEuropa\EPoetry\Notification\Exception\NotificationValidationException;
+use OpenEuropa\EPoetry\TicketValidation\ECas\ECasTicketValidation;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class ReceiveNotificationWithECasTest extends BaseNotificationTest
+{
+    /**
+     * @dataProvider dataProviderValidateRequest
+     */
+    public function testValidateRequestWithTicket(
+        string $jobAccount,
+        string $body,
+        string $exception,
+        bool $expected
+    ): void {
+        $validation = new ECasTicketValidation($jobAccount, $this->getCas());
+        $request = new ServerRequest('POST', 'http://foo', [], $body);
+
+        if ('' !== $exception) {
+            $this->expectException(NotificationValidationException::class);
+            $this->expectExceptionMessage($exception);
+        }
+
+        $this::assertEquals($expected, $validation->validate($request));
+    }
+
+    public function dataProviderValidateRequest(): \Generator
+    {
+        yield 'Empty headers' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '',
+            'exception' => 'EU Login ticket validation failed due to the following error: DOMDocument::loadXML(): Argument #1 ($source) must not be empty',
+            'expected' => false,
+        ];
+        yield 'Empty body' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '',
+            'exception' => 'EU Login ticket validation failed due to the following error: DOMDocument::loadXML(): Argument #1 ($source) must not be empty',
+            'expected' => false,
+        ];
+        yield 'Invalid body format ' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '{"foo": "bar"}',
+            'exception' => "EU Login ticket validation failed due to the following error: Could not load the DOM Document
+[FATAL] : Start tag expected, '<' not found
+ (4) on line 1,1",
+            'expected' => false,
+        ];
+        yield 'ProxyTicket not found' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => 'EU Login ticket validation failed due to the following error: Request body element <ProxyTicket/> not found.',
+            'expected' => false,
+        ];
+        yield 'ProxyTicket empty' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                                <ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws"></ecas:ProxyTicket>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => 'EU Login ticket validation failed due to the following error: Request body element <ProxyTicket/> found, but empty.',
+            'expected' => false,
+        ];
+        yield 'Valid CAS ticket' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                                <ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">VALIDTICKET</ecas:ProxyTicket>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => '',
+            'expected' => true,
+        ];
+        yield 'Valid CAS ticket with account mismatch' => [
+            'jobAccount' => 'foobar',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                                <ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">VALIDTICKET-WRONG-USERNAME</ecas:ProxyTicket>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => 'EU Login ticket account mismatched: foobar was expected, while username was returned.',
+            'expected' => false,
+        ];
+        yield 'Invalid CAS ticket' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                                <ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">INVALIDTICKET</ecas:ProxyTicket>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => 'EU Login ticket validation failed with the following error: 0 CAS authentication failure',
+            'expected' => false,
+        ];
+        yield 'Valid CAS ticket, but error 500' => [
+            'jobAccount' => 'jobAccount',
+            'body' => '<?xml version="1.0" encoding="UTF-8"?>
+                        <S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                            <env:Header>
+                                <ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">VALIDTICKET-ERROR500</ecas:ProxyTicket>
+                            </env:Header>
+                            <S:Body>
+                                <ns0:receiveNotification xmlns:ns0="http://eu.europa.ec.dgt.epoetry">
+                                    <notification></notification>
+                                </ns0:receiveNotification>
+                            </S:Body>
+                        </S:Envelope>',
+            'exception' => 'EU Login ticket validation failed with the following error: 0 Unable to a CAS response with response status code: 500.',
+            'expected' => false,
+        ];
+    }
+
+    private function getCas(): CasInterface
+    {
+        $ecasProperties = new EcasProperties(new Properties([
+            'base_url' => 'http://local/cas',
+            'protocol' => [
+                'serviceValidate' => [
+                    'path' => '/strictValidate',
+                ],
+            ],
+        ]));
+
+        $httpClient = new MockHttpClient(
+            static function ($method, $url, $options): ResponseInterface {
+                $info = match ($url) {
+                    'http://local/cas/strictValidate?format=JSON&service=http%3A%2F%2Ffoo&ticket=VALIDTICKET-ERROR500' =>
+                        [
+                            'http_code' => 500,
+                        ],
+                        default =>
+                        [
+                            'response_headers' => [
+                                'Content-Type' => 'application/json',
+                            ],
+                        ]
+                };
+
+                $body = match ($url) {
+                    'http://local/cas/strictValidate?format=JSON&service=http%3A%2F%2Ffoo&ticket=VALIDTICKET-ERROR500' =>
+                        '
+                        {
+                            "serviceResponse": {
+                                "authenticationSuccess": {
+                                    "user": "jobAccount"
+                                }
+                            }
+                        }
+                        ',
+                    'http://local/cas/strictValidate?format=JSON&service=http%3A%2F%2Ffoo&ticket=VALIDTICKET' =>
+                        '
+                        {
+                            "serviceResponse": {
+                                "authenticationSuccess": {
+                                    "user": "jobAccount"
+                                }
+                            }
+                        }
+                        ',
+                    'http://local/cas/strictValidate?format=JSON&service=http%3A%2F%2Ffoo&ticket=VALIDTICKET-WRONG-USERNAME' =>
+                        '
+                        {
+                            "serviceResponse": {
+                                "authenticationSuccess": {
+                                    "user": "username"
+                                }
+                            }
+                        }
+                        ',
+                    'http://local/cas/strictValidate?format=JSON&service=http%3A%2F%2Ffoo&ticket=INVALIDTICKET' =>
+                        '
+                        {
+                            "serviceResponse": {
+                                "authenticationFailure": {
+                                    "description": "The provided ticket is invalid."
+                                }
+                            }
+                        }
+                        ',
+                    default => throw new Exception(sprintf('URL %s is not defined in the HTTP mock client.', $url))
+                };
+
+                return new MockResponse($body, $info);
+            }
+        );
+
+        $psr17factory = new Psr17Factory;
+        $psr17 = new Psr17($psr17factory, $psr17factory, $psr17factory, $psr17factory, $psr17factory, $psr17factory);
+
+        $casResponseBuilder = new CasResponseBuilder(
+            new AuthenticationFailureFactory(),
+            new ProxyFactory(),
+            new ProxyFailureFactory(),
+            new ServiceValidateFactory()
+        );
+
+        $cas = new Cas(
+            $ecasProperties,
+            new Psr18Client($httpClient),
+            $psr17,
+            new ArrayAdapter,
+            $casResponseBuilder
+        );
+
+        $ecasResponseBuilder = new EcasResponseBuilder(
+            $casResponseBuilder
+        );
+
+        return new Ecas(
+            $cas,
+            $ecasProperties,
+            $psr17,
+            $ecasResponseBuilder,
+            new Psr18Client($httpClient),
+            new DefaultFingerprint
+        );
+    }
+}


### PR DESCRIPTION
This PR:

  - Introduces a new `TicketValidationInterface` concrete implementation, utilizing the [`ecphp/ecas` ](https://github.com/ecphp/ecas)library. This implementation does not return `false` but instead **throws exceptions** when issues arise, requiring users to handle exceptions appropriately. To **ensure** that developers catch exceptions as needed, we must verify that the calling code is equipped to handle them properly.
  - Test: The updated tests focus on evaluating the public interface, while private methods are indirectly tested through the expanded PHPUnit `data provider`  list that accommodates various use cases. This approach enables thorough coverage of the codebase while maintaining appropriate encapsulation of private methods.
  - Is related to #64 