### PR TITLE
chore: relax constraint of `psr/log`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/http-client-implementation": "*",
         "psr/http-factory": "^1",
         "psr/http-factory-implementation": "*",
-        "psr/log": "^3",
+        "psr/log": "^2 || ^3",
         "symfony/serializer": "~5.4 || ~6",
         "symfony/validator": "~5.4 || ~6",
         "veewee/xml": "^2.0"


### PR DESCRIPTION
`psr/log` support or `^3` but not `^2` which is still required by some libraires.

This PR fixes this behavior by allowing any version.

This won't have any impact:

- https://packagist.org/packages/psr/log#2.0.0
- https://packagist.org/packages/psr/log#3.0.0