### PR TITLE
chore: relax `psr/log` constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/http-client-implementation": "*",
         "psr/http-factory": "^1",
         "psr/http-factory-implementation": "*",
-        "psr/log": "^1 || ^3",
+        "psr/log": "^1 || ^2 || ^3",
         "symfony/serializer": "~4",
         "symfony/validator": "~4",
         "veewee/xml": "^1.0"


### PR DESCRIPTION
`psr/log` support `^1` or `^3` but not `^2` which is still required by some libraires.

This PR fixes this behavior by allowing any version.

This won't have any impact:

- https://packagist.org/packages/psr/log#2.0.0
- https://packagist.org/packages/psr/log#3.0.0