### PR TITLE
EWPP-2965: Symfony http client is required by ClientCertificateAuthentication.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "psr/http-factory": "^1",
         "psr/http-factory-implementation": "*",
         "psr/log": "^2 || ^3",
+        "symfony/http-client": "~5.4 || ~6",
         "symfony/serializer": "~5.4 || ~6",
         "symfony/validator": "~5.4 || ~6",
         "veewee/xml": "^2.0"
@@ -36,7 +37,6 @@
         "react/http": "^1.8",
         "symfony/dotenv": "~5.4 || ~6",
         "symfony/expression-language": "~5.4 || ~6",
-        "symfony/http-client": "~5.4 || ~6",
         "symfony/http-kernel": "~5.4 || ~6",
         "symfony/monolog-bridge": "~5.4 || ~6",
         "symfony/property-access": "~5.4 || ~6",


### PR DESCRIPTION
See https://github.com/openeuropa/epoetry-client/blob/2.x/src/Authentication/ClientCertificate/ClientCertificateAuthentication.php#L18