### PR TITLE
fix: replace `getenv` with `$_ENV`

### DIFF
--- a/bin/epoetry
+++ b/bin/epoetry
@@ -29,7 +29,7 @@ if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
 $dotenv = new Dotenv();
 $dotenv->loadEnv(__DIR__.'/../.env');
 
-$kernel = new AppKernel(getenv('EPOETRY_CONSOLE_ENV'), getenv('EPOETRY_CONSOLE_DEBUG'));
+$kernel = new AppKernel($_ENV['EPOETRY_CONSOLE_ENV'], $_ENV['EPOETRY_CONSOLE_DEBUG']);
 $kernel->boot();
 $container = $kernel->getContainer();
 $application = $container->get(Application::class);


### PR DESCRIPTION
Hi colleagues,

The GROW team reported that they are unable to execute `bin/epoetry` on their server. I also successfully replicated the issue locally using the current `2.x` branch and PHP 8.2.10 (ZTS or NTS). The failure appears to come from the usage of `getenv` to retrieve environment variables.

#### Steps to Reproduce
1. Navigate to `~/<dirs>/epoetry-client`
2. Run `bin/epoetry`

```
Fatal error: Uncaught InvalidArgumentException: Invalid environment provided to "OpenEuropa\EPoetry\Console\AppKernel": the environment cannot be empty. in /home/devlin/Code/b4/ecphp/epoetry-client/vendor/symfony/http-kernel/Kernel.php:92
```

The issue appears to be related to calls made using `getenv`. This approach is generally discouraged as `getenv` and `putenv` are not thread-safe. The PHP community and developers often use superglobal variables `$_ENV` or `$_SERVER` to obtain environment variables.

For reference, the Symfony team has also transitioned to prioritizing superglobal variables for obtaining environment variables (see [this commit](https://github.com/symfony/dotenv/commit/60fcd881c6f26f7092e3fae3d567332e4db6b839)).

#### Suggested Fix
- Replace `getenv` calls with superglobal variables like `$_ENV` or `$_SERVER` where applicable.