### PR TITLE
EWPP-3789: Fix test flakiness due to inconsistent SOAP XML generation

### DIFF
--- a/tests/RequestClientFactoryTest.php
+++ b/tests/RequestClientFactoryTest.php
@@ -26,7 +26,7 @@ final class RequestClientFactoryTest extends BaseTest
 
     public function testProxyTicket(): void
     {
-        $expectedHeader = '<soap:Header xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">[proxy ticket]</ecas:ProxyTicket></soap:Header>';
+        $expectedHeader = '<ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">[proxy ticket]</ecas:ProxyTicket>';
         $expectedBody = '<SOAP-ENV:Body><ns1:createLinguisticRequest><requestDetails><title>Request title</title>';
 
         $mockClient = new MockClient();
@@ -97,6 +97,7 @@ final class RequestClientFactoryTest extends BaseTest
         $this->assertTrue($logger->hasInfoThatContains('[phpro/soap-client] response: OpenEuropa\EPoetry\Request\Type\CreateLinguisticRequestResponse Object'));
 
         // Assert ePoetry library logging messages.
+        $logger->records[1]['context']['formatted_request'] = $this->stripHeaderAttributes($logger->records[1]['context']['formatted_request']);
         $this->assertEquals(
             [
                 'level' => 'info',
@@ -109,7 +110,7 @@ SOAPAction: ""
 Content-Type: text/xml; charset="utf-8"
 
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://eu.europa.ec.dgt.epoetry"><soap:Header xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">12345</ecas:ProxyTicket></soap:Header><SOAP-ENV:Body><ns1:createLinguisticRequest><requestDetails><title>Request title</title><requestedDeadline>2121-07-06T11:51:00+01:00</requestedDeadline><sensitive>false</sensitive><destination>PUBLIC</destination><procedure>DEGHP</procedure><slaAnnex>ANNEX8A</slaAnnex><slaCommitment>2225555</slaCommitment><comment>comment</comment><accessibleTo>CONTACTS</accessibleTo><keyword1>keyword1</keyword1><keyword2>keyword2</keyword2><keyword3>keyword3</keyword3><contacts><contact userId="smithjo" contactRole="REQUESTER"/><contact userId="smithjo" contactRole="AUTHOR"/><contact userId="smithjo" contactRole="RECIPIENT"/></contacts><originalDocument><fileName>TEST_FILE_ORIGINALP.docx</fileName><comment/><content>Y2lkOjI2NzczNjgyODUzMQ==</content><linguisticSections/><trackChanges>false</trackChanges></originalDocument><products><product requestedDeadline="2121-07-06T11:51:00+01:00" trackChanges="false"><language>FR</language></product></products><auxiliaryDocuments><referenceDocuments><document><fileName>test.docx</fileName><language>EN</language><comment>test</comment><content>Y2lkOjMwMzYwNTgyNDExMg==</content></document></referenceDocuments><srcDocument><fileName>test2222SRC.docx</fileName><comment>777888877</comment><content>Y2lkOjE1MzE4ODQ3MDQyMjY=</content></srcDocument></auxiliaryDocuments></requestDetails><applicationName>appname</applicationName><templateName>DEFAULT</templateName></ns1:createLinguisticRequest></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://eu.europa.ec.dgt.epoetry"><soap:Header><ecas:ProxyTicket xmlns:ecas="https://ecas.ec.europa.eu/cas/schemas/ws">12345</ecas:ProxyTicket></soap:Header><SOAP-ENV:Body><ns1:createLinguisticRequest><requestDetails><title>Request title</title><requestedDeadline>2121-07-06T11:51:00+01:00</requestedDeadline><sensitive>false</sensitive><destination>PUBLIC</destination><procedure>DEGHP</procedure><slaAnnex>ANNEX8A</slaAnnex><slaCommitment>2225555</slaCommitment><comment>comment</comment><accessibleTo>CONTACTS</accessibleTo><keyword1>keyword1</keyword1><keyword2>keyword2</keyword2><keyword3>keyword3</keyword3><contacts><contact userId="smithjo" contactRole="REQUESTER"/><contact userId="smithjo" contactRole="AUTHOR"/><contact userId="smithjo" contactRole="RECIPIENT"/></contacts><originalDocument><fileName>TEST_FILE_ORIGINALP.docx</fileName><comment/><content>Y2lkOjI2NzczNjgyODUzMQ==</content><linguisticSections/><trackChanges>false</trackChanges></originalDocument><products><product requestedDeadline="2121-07-06T11:51:00+01:00" trackChanges="false"><language>FR</language></product></products><auxiliaryDocuments><referenceDocuments><document><fileName>test.docx</fileName><language>EN</language><comment>test</comment><content>Y2lkOjMwMzYwNTgyNDExMg==</content></document></referenceDocuments><srcDocument><fileName>test2222SRC.docx</fileName><comment>777888877</comment><content>Y2lkOjE1MzE4ODQ3MDQyMjY=</content></srcDocument></auxiliaryDocuments></requestDetails><applicationName>appname</applicationName><templateName>DEFAULT</templateName></ns1:createLinguisticRequest></SOAP-ENV:Body></SOAP-ENV:Envelope>
 ',
                     ],
             ],
@@ -228,5 +229,22 @@ Content-Type: text/xml; charset="utf-8"
             ],
             $logger->records[2]
         );
+    }
+
+    /**
+     * Strip xmlns attributes in headers before asserting.
+     *
+     * Depending on the PHP version we may or may not get an extra `xmlns`
+     * namespace on `<soap:Header>`. This has no effect on the communication
+     * with the actual ePoetry service, so we will just amend the tests to
+     * account for that.
+     *
+     * @param string $request
+     *
+     * @return string
+     */
+    protected function stripHeaderAttributes(string $request): string
+    {
+        return preg_replace('/<soap:Header([^>]*)xmlns[^>]*>/i', '<soap:Header>', $request);
     }
 }


### PR DESCRIPTION
Depending on the PHP version we may or may not get an extra `xmlns` namespace on `<soap:Header>`. This has no effect on the communication with the actual ePoetry service, so we will just amend the tests to account for that.