### PR TITLE
#83 Make the package compatible with php 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "cweagans/composer-patches": "^1 || ^2",
         "php-http/logger-plugin": "^1",
         "php-http/message": "~1.13",
-        "phpro/soap-client": "~2.4",
+        "phpro/soap-client": "^3",
         "psr/http-client": "^1",
         "psr/http-client-implementation": "*",
         "psr/http-factory": "^1",
@@ -69,13 +69,5 @@
     },
     "bin": ["bin/epoetry"],
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "extra": {
-        "patches": {
-            "phpro/soap-client" : {
-                "https://github.com/phpro/soap-client/issues/446": "https://patch-diff.githubusercontent.com/raw/phpro/soap-client/pull/448.diff",
-                "https://github.com/phpro/soap-client/issues/444": "https://patch-diff.githubusercontent.com/raw/phpro/soap-client/pull/445.diff"
-            }
-        }
-    }
+    "prefer-stable": true
 }


### PR DESCRIPTION
### Description

Make the package compatible with PHP 8.3

### Change log

- Changed: Update the phpro/soap-client

### Commands

```sh
#Using php 8.1, 8.2 & 8.3 run
composer install
```

