### PR TITLE
Add nullable type to parameters that accept null

### DIFF
--- a/src/CodeGenerator/Assembler/AbstractAssembler.php
+++ b/src/CodeGenerator/Assembler/AbstractAssembler.php
@@ -79,7 +79,7 @@ abstract class AbstractAssembler implements AssemblerInterface
      * @return string
      *   The FQCN shortened
      */
-    protected function shortenNamespace(string $type, string $namespace = null)
+    protected function shortenNamespace(string $type, ?string $namespace = null)
     {
         $namespace = '\\' . trim($namespace, '\\') . '\\';
 

--- a/src/CodeGenerator/Assembler/AbstractAssemblerOptions.php
+++ b/src/CodeGenerator/Assembler/AbstractAssemblerOptions.php
@@ -38,7 +38,7 @@ abstract class AbstractAssemblerOptions
      *
      * @return bool
      */
-    public function isBlacklisted(string $className, string $propertyName = null): bool
+    public function isBlacklisted(string $className, ?string $propertyName = null): bool
     {
         if ($this->blacklist === null) {
             return false;
@@ -57,7 +57,7 @@ abstract class AbstractAssemblerOptions
      *
      * @return bool
      */
-    public function isWhitelisted(string $className, string $propertyName = null): bool
+    public function isWhitelisted(string $className, ?string $propertyName = null): bool
     {
         if ($this->whitelist === null) {
             return true;

--- a/src/CodeGenerator/Assembler/FluentAdderAssembler.php
+++ b/src/CodeGenerator/Assembler/FluentAdderAssembler.php
@@ -21,9 +21,9 @@ class FluentAdderAssembler extends AbstractAssembler
     /**
      * FluentAdderAssembler constructor.
      *
-     * @param \OpenEuropa\EPoetry\CodeGenerator\Assembler\FluentAdderAssemblerOptions $options
+     * @param \OpenEuropa\EPoetry\CodeGenerator\Assembler\FluentAdderAssemblerOptions|null $options
      */
-    public function __construct(FluentAdderAssemblerOptions $options = null)
+    public function __construct(?FluentAdderAssemblerOptions $options = null)
     {
         $this->options = $options ?? new FluentAdderAssemblerOptions();
     }

--- a/src/Console/Monolog/ReactConsoleHandler.php
+++ b/src/Console/Monolog/ReactConsoleHandler.php
@@ -31,7 +31,7 @@ class ReactConsoleHandler implements HandlerInterface
      */
     protected int $verbosity;
 
-    public function __construct(LoopInterface $loop, StreamOutput $output = null, bool $bubble = true, array $verbosityLevelMap = [], array $consoleFormatterOptions = [])
+    public function __construct(LoopInterface $loop, ?StreamOutput $output = null, bool $bubble = true, array $verbosityLevelMap = [], array $consoleFormatterOptions = [])
     {
         $this->consoleHandler = new ConsoleHandler($output, $bubble, $verbosityLevelMap, [
             'format' => "%datetime% %level_name% [%channel%] %message%%context%%extra%\n",

--- a/src/Notification/Event/Product/BaseEventWithDeadline.php
+++ b/src/Notification/Event/Product/BaseEventWithDeadline.php
@@ -12,7 +12,7 @@ abstract class BaseEventWithDeadline extends BaseEvent implements ProductEventWi
      * @param \OpenEuropa\EPoetry\Notification\Type\Product $product
      * @param \DateTimeInterface|null $acceptedDeadline
      */
-    public function __construct(Product $product, \DateTimeInterface $acceptedDeadline = null)
+    public function __construct(Product $product, ?\DateTimeInterface $acceptedDeadline = null)
     {
         parent::__construct($product);
         $this->acceptedDeadline = $acceptedDeadline;

--- a/src/RequestClientFactory.php
+++ b/src/RequestClientFactory.php
@@ -93,7 +93,7 @@ class RequestClientFactory
      * @param ClientInterface|null $httpClient
      * @param Transport|null $transport
      */
-    public function __construct(string $endpoint, AuthenticationInterface $authentication, EventDispatcherInterface $eventDispatcher = null, LoggerInterface $logger = null, ClientInterface $httpClient = null, Transport $transport = null)
+    public function __construct(string $endpoint, AuthenticationInterface $authentication, ?EventDispatcherInterface $eventDispatcher = null, ?LoggerInterface $logger = null, ?ClientInterface $httpClient = null, ?Transport $transport = null)
     {
         $this->endpoint = $endpoint;
         $this->eventDispatcher = $eventDispatcher ?? new EventDispatcher();

--- a/src/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Serializer/Normalizer/DateTimeNormalizer.php
@@ -20,7 +20,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): \DateTimeInterface
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): \DateTimeInterface
     {
         if ($type === \DateTimeInterface::class) {
             // Force to build \DateTime objects instead of \DateTimeImmutable.


### PR DESCRIPTION
With PHP 8.4, we have this deprecation:
```
Deprecated: OpenEuropa\EPoetry\Notification\Event\Product\BaseEventWithDeadline::__construct(): Implicitly marking parameter $acceptedDeadline as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/openeuropa/epoetry-client/src/Notification/Event/Product/BaseEventWithDeadline.php line 15
```

So the nullable type should be explicitly added to all parameters that accept null.