### PR TITLE
EWPP-7028: Remove unused doctrine annotations library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "phpdocumentor/reflection-docblock": "^5",
         "phpunit/phpunit": "~9.6",
         "react/http": "^1.8",
+        "replace-azjezz/psl": "0.0.0",
         "symfony/config": "~7",
         "symfony/dependency-injection": "~7",
         "symfony/dotenv": "~7",
@@ -46,6 +47,19 @@
         "symfony/property-info": "~7",
         "web-token/jwt-framework": "^4.0"
     },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "replace-azjezz/psl",
+                "type": "metapackage",
+                "version": "0.0.0",
+                "replace": {
+                    "azjezz/psl": "*"
+                }
+            }
+        }
+    ],
     "suggest": {
         "symfony/console": "The Symfony Console component eases the creation of command line interfaces. Require this in your project if you wish to use the ePoetry Console.",
         "facile-it/php-openid-client": "Require this in your project if you use the OpenID Connect authentication plugin.",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     },
     "require-dev": {
         "colinodell/psr-testlogger": "^1.1",
-        "doctrine/annotations": "^1.13",
         "facile-it/php-openid-client": "^0.3.5",
         "monolog/monolog": "~3",
         "nyholm/psr7": "^1.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
+    <ini name="date.timezone" value="UTC"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
   </php>
   <testsuites>

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -11,6 +11,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -64,7 +65,7 @@ abstract class BaseTest extends TestCase
      */
     public function getFixture(string $filename, $dir = ''): array
     {
-        return Yaml::parse(file_get_contents(__DIR__ . $dir .  '/fixtures/' . $filename));
+        return Yaml::parse(file_get_contents(__DIR__ . $dir .  '/fixtures/' . $filename), maxAliasesForCollections: 512);
     }
 
     /**

--- a/tests/CodeGenerator/Assembler/FluentAdderAssemblerTest.php
+++ b/tests/CodeGenerator/Assembler/FluentAdderAssemblerTest.php
@@ -45,7 +45,7 @@ class MyType
      * @param string ...$prop1s
      * @return $this
      */
-    public function addProp1(... $prop1s) : \MyNamespace\MyType
+    public function addProp1(... $prop1s): \MyNamespace\MyType
     {
         $this->prop1 = array_merge($this->prop1, $prop1s);return $this;
     }

--- a/tests/CodeGenerator/Assembler/HasPropertyAssemblerTest.php
+++ b/tests/CodeGenerator/Assembler/HasPropertyAssemblerTest.php
@@ -36,7 +36,7 @@ class MyType
     /**
      * @return bool
      */
-    public function hasProp1() : bool
+    public function hasProp1(): bool
     {
         return !empty($this->prop1);
     }


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

